### PR TITLE
add og:image for linkedin thumbnail

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="image" property="og:image" content="https://live.staticflickr.com/65535/50562376467_2285f72e08_z.jpg" />
     <title><%= content_for?(:title) ? yield(:title) : "BookableApp" %></title>
     <%= csrf_meta_tags %>
     <%= stylesheet_link_tag "application", :media => "all" %>


### PR DESCRIPTION
- Add 'og:image' in meta tag for thumbnails on social media